### PR TITLE
[DRAFT] Added function to save stack traces in a specific time interval

### DIFF
--- a/src/wasm/main.cpp
+++ b/src/wasm/main.cpp
@@ -1,0 +1,41 @@
+#include "tree_parse.hpp"
+
+int main() {
+    std::ifstream file("data2.json"); //this is only for test
+    json j;
+    file >> j;
+
+    u_int16_t start_time = 0;
+
+    if(j.contains("first_time")){
+         if (j["first_time"].is_number_unsigned()) {
+            start_time = j["first_time"].get<uint64_t>();
+        } else if (j["first_time"].is_number_integer()) {
+            start_time = static_cast<uint64_t>(j["first_time"].get<int64_t>());
+        }
+    }
+
+    if (j.contains("walltime") && j["walltime"].size() > 1) {
+        TreeNode second_node = parse_json_to_tree(j["walltime"][1]); //time ordered json
+
+        uint64_t running_sum = 0;
+        calculate_left_sum(second_node, running_sum);
+
+       
+        uint64_t threshold_left = 100000000; // - start_time if needed
+        uint64_t threshold_right = 8000000000; // - start_time if needed
+
+        TreeNode pruned_tree = prune_tree(second_node, threshold_left, threshold_right);
+
+        json pruned_tree_json = tree_to_json(pruned_tree);
+        save_json_to_file(pruned_tree_json, "pruned_tree.json");
+
+        std::cout << "\nPruned Tree :\n"; //tree that only includes nodes which overlap with the time period between with two thresholds
+        print_tree(pruned_tree);
+
+    } else {
+        std::cerr << "The walltime array does not have at least two elements." << std::endl;
+    }
+
+    return 0;
+}

--- a/src/wasm/main.cpp
+++ b/src/wasm/main.cpp
@@ -12,11 +12,7 @@ TreeNode parse_json_to_tree(const json& j_node) {
     node.value = 0;
     
     if (j_node.contains("value")) {
-        if (j_node["value"].is_number_unsigned()) {
-            node.value = j_node["value"].get<uint64_t>();
-        } else if (j_node["value"].is_number_integer()) {
-            node.value = static_cast<uint64_t>(j_node["value"].get<int64_t>());
-        }
+        node.value = j_node["value"].get<uint64_t>();
     }
 
     node.cold = j_node.value("cold", false);
@@ -73,11 +69,7 @@ int main() {
     u_int16_t start_time = 0;
 
     if(j.contains("first_time")){
-         if (j["first_time"].is_number_unsigned()) {
-            start_time = j["first_time"].get<uint64_t>();
-        } else if (j["first_time"].is_number_integer()) {
-            start_time = static_cast<uint64_t>(j["first_time"].get<int64_t>());
-        }
+        start_time = j["first_time"].get<uint64_t>();
     }
 
     if (j.contains("walltime") && j["walltime"].size() > 1) {
@@ -97,7 +89,7 @@ int main() {
 
 
 
-        std::cout << "\nPruned Tree :\n"; //tree that only includes nodes which overlap with the time period between with two thresholds
+        std::cout << "\nFull Tree :\n"; //tree that only includes nodes which overlap with the time period between with two thresholds
         print_tree(second_node);
 
         std::cout << "\nPruned Tree :\n"; //tree that only includes nodes which overlap with the time period between with two thresholds

--- a/src/wasm/main.cpp
+++ b/src/wasm/main.cpp
@@ -1,4 +1,3 @@
-
 #include <nlohmann/json.hpp>
 #include "tree_parse.hpp"
 #include <iostream>
@@ -6,98 +5,99 @@
 
 using json = nlohmann::json;
 
-TreeNode parse_json_to_tree(const json& j_node) {
-    TreeNode node;
-    node.name = j_node.value("name", "");
-    node.value = 0;
-    
-    if (j_node.contains("value")) {
-        node.value = j_node["value"].get<uint64_t>();
-    }
+TreeNode parse_json_to_tree(const json &j_node) {
+  TreeNode node;
+  node.name = j_node.value("name", "");
+  node.value = 0;
 
-    node.cold = j_node.value("cold", false);
-    node.left_sum = 0;
+  if (j_node.contains("value")) {
+    node.value = j_node["value"].get<uint64_t>();
+  }
 
-    if (j_node.contains("children")) {
-        for (const auto& child : j_node["children"]) {
-            node.children.push_back(parse_json_to_tree(child));
-        }
+  node.cold = j_node.value("cold", false);
+  node.left_sum = 0;
+
+  if (j_node.contains("children")) {
+    for (const auto &child : j_node["children"]) {
+      node.children.push_back(parse_json_to_tree(child));
     }
-    return node;
+  }
+
+  return node;
 }
 
+json tree_to_json(const TreeNode &node) {
+  json j_node;
+  j_node["name"] = node.name;
+  j_node["value"] = node.value;
+  j_node["left_sum"] = node.left_sum;
+  j_node["cold"] = node.cold;
 
+  for (const auto &child : node.children) {
+    j_node["children"].push_back(tree_to_json(child));
+  }
 
-json tree_to_json(const TreeNode& node) {
-    json j_node;
-    j_node["name"] = node.name;
-    j_node["value"] = node.value;
-    j_node["left_sum"] = node.left_sum;
-    j_node["cold"] = node.cold;
-
-    for (const auto& child : node.children) {
-        j_node["children"].push_back(tree_to_json(child));
-    }
-
-    return j_node;
+  return j_node;
 }
 
-void save_json_to_file(const json& j, const std::string& filename) {
-    std::ofstream file(filename);
-    if (file.is_open()) {
-        file << j.dump();
-        file.close();
-    } else {
-        std::cerr << "Unable to open file: " << filename << std::endl;
-    }
+void save_json_to_file(const json &j, const std::string &filename) {
+  std::ofstream file(filename);
+  if (file.is_open()) {
+    file << j.dump();
+    file.close();
+  } else {
+    std::cerr << "Unable to open file: " << filename << std::endl;
+  }
 }
 
-void print_tree(const TreeNode& node, int level = 0) {
-    std::string indent(level * 2, ' ');
-    std::cout << indent << "Name: " << node.name << ", Value: " << node.value << ", Left Sum: " << node.left_sum << "\n";
-    for (const auto& child : node.children) {
-        print_tree(child, level + 1);
-    }
+void print_tree(const TreeNode &node, int level = 0) {
+  std::string indent(level * 2, ' ');
+  std::cout << indent << "Name: " << node.name << ", Value: " <<
+    node.value << ", Left Sum: " << node.left_sum << "\n";
+  for (const auto &child : node.children) {
+    print_tree(child, level + 1);
+  }
 }
-
 
 int main() {
-    std::ifstream file("data2.json"); //this is only for test
-    json j;
-    file >> j;
+  std::ifstream file("data2.json"); // this is only for test
+  json j;
+  file >> j;
 
-    u_int16_t start_time = 0;
+  u_int16_t start_time = 0;
 
-    if(j.contains("first_time")){
-        start_time = j["first_time"].get<uint64_t>();
-    }
+  if (j.contains("first_time")) {
+    start_time = j["first_time"].get<uint64_t>();
+  }
 
-    if (j.contains("walltime") && j["walltime"].size() > 1) {
-        TreeNode second_node = parse_json_to_tree(j["walltime"][1]); //time ordered json
+  if (j.contains("walltime") && j["walltime"].size() > 1) {
+    TreeNode second_node = parse_json_to_tree(j["walltime"][1]); // time ordered json
 
-        uint64_t running_sum = 0;
-        calculate_left_sum(second_node, running_sum);
+    uint64_t running_sum = 0;
+    calculate_left_sum(second_node, running_sum);
 
-       
-        uint64_t threshold_left =  100000000; // - start_time if needed
-        uint64_t threshold_right = 200000000; // - start_time if needed
+    uint64_t threshold_left =  100000000; // - start_time if needed
+    uint64_t threshold_right = 200000000; // - start_time if needed
 
-        TreeNode pruned_tree = prune_tree(second_node, threshold_left, threshold_right);
+    TreeNode pruned_tree = prune_tree(second_node, threshold_left,
+                                      threshold_right);
 
-        json pruned_tree_json = tree_to_json(pruned_tree);
-        save_json_to_file(pruned_tree_json, "pruned_tree.json");
+    json pruned_tree_json = tree_to_json(pruned_tree);
+    save_json_to_file(pruned_tree_json, "pruned_tree.json");
 
+    // tree that only includes nodes which overlap with the time period
+    // between with two thresholds
+    std::cout << "\nFull Tree :\n";
+    print_tree(second_node);
 
+    // tree that only includes nodes which overlap with the time period
+    // between with two thresholds
+    std::cout << "\nPruned Tree :\n";
+    print_tree(pruned_tree);
 
-        std::cout << "\nFull Tree :\n"; //tree that only includes nodes which overlap with the time period between with two thresholds
-        print_tree(second_node);
+  } else {
+    std::cerr << "The walltime array does not have at least two elements." << std::endl;
+  }
 
-        std::cout << "\nPruned Tree :\n"; //tree that only includes nodes which overlap with the time period between with two thresholds
-        print_tree(pruned_tree);
-
-    } else {
-        std::cerr << "The walltime array does not have at least two elements." << std::endl;
-    }
-
-    return 0;
+  return 0;
 }

--- a/src/wasm/tree_parse.cpp
+++ b/src/wasm/tree_parse.cpp
@@ -1,38 +1,46 @@
-#include <iostream>
-#include <vector>
-#include <unordered_map>
 #include "tree_parse.hpp"
 
-uint64_t calculate_left_sum(TreeNode& node, uint64_t& running_sum) {
-    if (node.children.empty()) {
-        node.left_sum = running_sum; //left_sum is the starting_time for the current function
-        running_sum += node.value;  // sum of leaf values (walltimes) to the left = start_time current
-        } else {
-        for (auto& child : node.children) {
-            calculate_left_sum(child, running_sum);
-        }
-        if (!node.children.empty()) {
-            node.left_sum = node.children.front().left_sum; //parent start_time = left most child start_time
-        }
+uint64_t calculate_left_sum(TreeNode &node, uint64_t &running_sum) {
+  if (node.children.empty()) {
+    // left_sum is the starting_time for the current function
+    node.left_sum = running_sum;
+    // sum of leaf values (walltimes) to the left = start_time current
+    running_sum += node.value;
+  } else {
+    for (auto &child : node.children) {
+      calculate_left_sum(child, running_sum);
     }
-    return node.left_sum;
+    if (!node.children.empty()) {
+      // parent start_time = left most child start_time
+      node.left_sum = node.children.front().left_sum;
+    }
+  }
+  return node.left_sum;
 }
 
-TreeNode prune_tree(const TreeNode& node, uint64_t threshold_left, uint64_t threshold_right) {
-    TreeNode pruned_node = node;
+TreeNode prune_tree(const TreeNode &node, uint64_t threshold_left,
+                    uint64_t threshold_right) {
+  TreeNode pruned_node = node;
 
-    pruned_node.children.clear();
+  pruned_node.children.clear();
 
-    for (const auto& child : node.children) {
-        //this includes all the functions that have any overlap with the time between the two thresholds
-        if ((child.left_sum + child.value) > threshold_left && (child.left_sum) < threshold_right) {
-            pruned_node.children.push_back(prune_tree(child, threshold_left, threshold_right));
-        }
+  for (const auto &child : node.children) {
+    // this includes all the functions that have any overlap
+    // with the time between the two thresholds
+    if ((child.left_sum + child.value) > threshold_left &&
+        child.left_sum < threshold_right) {
+      pruned_node.children.push_back(prune_tree(child, threshold_left,
+                                                threshold_right));
     }
+  }
 
-    uint64_t extra_time_left = threshold_left > node.left_sum ? threshold_left - node.left_sum : 0;
-    uint64_t extra_time_right = (node.left_sum + node.value) > threshold_right ? node.left_sum + node.value - threshold_right : 0;
-    pruned_node.value = node.value - extra_time_left - extra_time_right; //substract extra left + right time intervals from walltime if any
+  uint64_t extra_time_left =
+    threshold_left > node.left_sum ? threshold_left - node.left_sum : 0;
+  uint64_t extra_time_right =
+    (node.left_sum + node.value) > threshold_right ?
+    node.left_sum + node.value - threshold_right : 0;
+  // substract extra left + right time intervals from walltime if any
+  pruned_node.value = node.value - extra_time_left - extra_time_right;
 
-    return pruned_node;
+  return pruned_node;
 }

--- a/src/wasm/tree_parse.cpp
+++ b/src/wasm/tree_parse.cpp
@@ -1,0 +1,93 @@
+#include <iostream>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <vector>
+#include <unordered_map>
+#include "tree_parse.hpp"
+
+using json = nlohmann::json;
+
+
+TreeNode parse_json_to_tree(const json& j_node) {
+    TreeNode node;
+    node.name = j_node.value("name", "");
+    node.value = 0;
+    
+    if (j_node.contains("value")) {
+        if (j_node["value"].is_number_unsigned()) {
+            node.value = j_node["value"].get<uint64_t>();
+        } else if (j_node["value"].is_number_integer()) {
+            node.value = static_cast<uint64_t>(j_node["value"].get<int64_t>());
+        }
+    }
+
+    node.cold = j_node.value("cold", false);
+    node.left_sum = 0;
+
+    if (j_node.contains("children")) {
+        for (const auto& child : j_node["children"]) {
+            node.children.push_back(parse_json_to_tree(child));
+        }
+    }
+    return node;
+}
+
+uint64_t calculate_left_sum(TreeNode& node, uint64_t& running_sum) {
+    if (node.children.empty()) {
+        node.left_sum = running_sum; //left_sum is the starting_time for the current function
+        running_sum += node.value;  // sum of leaf values (walltimes) to the left = start_time current
+        } else {
+        for (auto& child : node.children) {
+            calculate_left_sum(child, running_sum);
+        }
+        if (!node.children.empty()) {
+            node.left_sum = node.children.front().left_sum; //parent start_time = left most child start_time
+        }
+    }
+    return node.left_sum;
+}
+
+TreeNode prune_tree(const TreeNode& node, uint64_t threshold_left, uint64_t threshold_right) {
+    TreeNode pruned_node = node;
+
+    pruned_node.children.clear();
+    for (const auto& child : node.children) {
+        //this includes all the functions that have any overlap with the time between the two thresholds
+        if ((child.left_sum + child.value) >= threshold_left && (child.left_sum) <= threshold_right) { 
+            pruned_node.children.push_back(prune_tree(child, threshold_left, threshold_right));
+        }
+    }
+    return pruned_node;
+}
+
+json tree_to_json(const TreeNode& node) {
+    json j_node;
+    j_node["name"] = node.name;
+    j_node["value"] = node.value;
+    j_node["left_sum"] = node.left_sum;
+    j_node["cold"] = node.cold;
+
+    for (const auto& child : node.children) {
+        j_node["children"].push_back(tree_to_json(child));
+    }
+
+    return j_node;
+}
+
+void save_json_to_file(const json& j, const std::string& filename) {
+    std::ofstream file(filename);
+    if (file.is_open()) {
+        file << j.dump();
+        file.close();
+    } else {
+        std::cerr << "Unable to open file: " << filename << std::endl;
+    }
+}
+
+void print_tree(const TreeNode& node, int level) {
+    std::string indent(level * 2, ' ');
+    std::cout << indent << "Name: " << node.name << ", Value: " << node.value << ", Left Sum: " << node.left_sum << "\n";
+    for (const auto& child : node.children) {
+        print_tree(child, level + 1);
+    }
+}

--- a/src/wasm/tree_parse.cpp
+++ b/src/wasm/tree_parse.cpp
@@ -51,12 +51,18 @@ TreeNode prune_tree(const TreeNode& node, uint64_t threshold_left, uint64_t thre
     TreeNode pruned_node = node;
 
     pruned_node.children.clear();
+
     for (const auto& child : node.children) {
         //this includes all the functions that have any overlap with the time between the two thresholds
-        if ((child.left_sum + child.value) >= threshold_left && (child.left_sum) <= threshold_right) { 
+        if ((child.left_sum + child.value) > threshold_left && (child.left_sum) < threshold_right) {
             pruned_node.children.push_back(prune_tree(child, threshold_left, threshold_right));
         }
     }
+
+    uint64_t extra_time_left = threshold_left > node.left_sum ? threshold_left - node.left_sum : 0;
+    uint64_t extra_time_right = (node.left_sum + node.value) > threshold_right ? node.left_sum + node.value - threshold_right : 0;
+    pruned_node.value = node.value - extra_time_left - extra_time_right; //substract extra left + right time intervals from walltime if any
+
     return pruned_node;
 }
 

--- a/src/wasm/tree_parse.cpp
+++ b/src/wasm/tree_parse.cpp
@@ -1,36 +1,7 @@
 #include <iostream>
-#include <fstream>
-#include <nlohmann/json.hpp>
 #include <vector>
 #include <unordered_map>
 #include "tree_parse.hpp"
-
-using json = nlohmann::json;
-
-
-TreeNode parse_json_to_tree(const json& j_node) {
-    TreeNode node;
-    node.name = j_node.value("name", "");
-    node.value = 0;
-    
-    if (j_node.contains("value")) {
-        if (j_node["value"].is_number_unsigned()) {
-            node.value = j_node["value"].get<uint64_t>();
-        } else if (j_node["value"].is_number_integer()) {
-            node.value = static_cast<uint64_t>(j_node["value"].get<int64_t>());
-        }
-    }
-
-    node.cold = j_node.value("cold", false);
-    node.left_sum = 0;
-
-    if (j_node.contains("children")) {
-        for (const auto& child : j_node["children"]) {
-            node.children.push_back(parse_json_to_tree(child));
-        }
-    }
-    return node;
-}
 
 uint64_t calculate_left_sum(TreeNode& node, uint64_t& running_sum) {
     if (node.children.empty()) {
@@ -64,36 +35,4 @@ TreeNode prune_tree(const TreeNode& node, uint64_t threshold_left, uint64_t thre
     pruned_node.value = node.value - extra_time_left - extra_time_right; //substract extra left + right time intervals from walltime if any
 
     return pruned_node;
-}
-
-json tree_to_json(const TreeNode& node) {
-    json j_node;
-    j_node["name"] = node.name;
-    j_node["value"] = node.value;
-    j_node["left_sum"] = node.left_sum;
-    j_node["cold"] = node.cold;
-
-    for (const auto& child : node.children) {
-        j_node["children"].push_back(tree_to_json(child));
-    }
-
-    return j_node;
-}
-
-void save_json_to_file(const json& j, const std::string& filename) {
-    std::ofstream file(filename);
-    if (file.is_open()) {
-        file << j.dump();
-        file.close();
-    } else {
-        std::cerr << "Unable to open file: " << filename << std::endl;
-    }
-}
-
-void print_tree(const TreeNode& node, int level) {
-    std::string indent(level * 2, ' ');
-    std::cout << indent << "Name: " << node.name << ", Value: " << node.value << ", Left Sum: " << node.left_sum << "\n";
-    for (const auto& child : node.children) {
-        print_tree(child, level + 1);
-    }
 }

--- a/src/wasm/tree_parse.hpp
+++ b/src/wasm/tree_parse.hpp
@@ -2,14 +2,8 @@
 #ifndef TREE_PARSE_H
 #define TREE_PARSE_H
 
-#include <iostream>
-#include <fstream>
-#include <nlohmann/json.hpp>
 #include <vector>
 #include <unordered_map>
-
-using json = nlohmann::json;
-
 
 struct TreeNode {
     std::string name;
@@ -19,16 +13,9 @@ struct TreeNode {
     std::vector<TreeNode> children;
 };
 
-TreeNode parse_json_to_tree(const json& j_node);
-
 uint64_t calculate_left_sum(TreeNode& node, uint64_t& running_sum);
 
 TreeNode prune_tree(const TreeNode& node, uint64_t threshold_left, uint64_t threshold_right);
 
-json tree_to_json(const TreeNode& node);
-
-void save_json_to_file(const json& j, const std::string& filename);
-
-void print_tree(const TreeNode& node, int level = 0);
 
 #endif // TREE_PARSE_H

--- a/src/wasm/tree_parse.hpp
+++ b/src/wasm/tree_parse.hpp
@@ -1,0 +1,34 @@
+// tree_parse.h
+#ifndef TREE_PARSE_H
+#define TREE_PARSE_H
+
+#include <iostream>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <vector>
+#include <unordered_map>
+
+using json = nlohmann::json;
+
+
+struct TreeNode {
+    std::string name;
+    uint64_t value;
+    uint64_t left_sum;
+    bool cold;
+    std::vector<TreeNode> children;
+};
+
+TreeNode parse_json_to_tree(const json& j_node);
+
+uint64_t calculate_left_sum(TreeNode& node, uint64_t& running_sum);
+
+TreeNode prune_tree(const TreeNode& node, uint64_t threshold_left, uint64_t threshold_right);
+
+json tree_to_json(const TreeNode& node);
+
+void save_json_to_file(const json& j, const std::string& filename);
+
+void print_tree(const TreeNode& node, int level = 0);
+
+#endif // TREE_PARSE_H

--- a/src/wasm/tree_parse.hpp
+++ b/src/wasm/tree_parse.hpp
@@ -3,19 +3,19 @@
 #define TREE_PARSE_H
 
 #include <vector>
-#include <unordered_map>
+#include <string>
+#include <cstdint>
 
 struct TreeNode {
-    std::string name;
-    uint64_t value;
-    uint64_t left_sum;
-    bool cold;
-    std::vector<TreeNode> children;
+  std::string name;
+  uint64_t value;
+  uint64_t left_sum;
+  bool cold;
+  std::vector<TreeNode> children;
 };
 
-uint64_t calculate_left_sum(TreeNode& node, uint64_t& running_sum);
-
-TreeNode prune_tree(const TreeNode& node, uint64_t threshold_left, uint64_t threshold_right);
-
+uint64_t calculate_left_sum(TreeNode &node, uint64_t &running_sum);
+TreeNode prune_tree(const TreeNode &node, uint64_t threshold_left,
+                    uint64_t threshold_right);
 
 #endif // TREE_PARSE_H


### PR DESCRIPTION
For now, this parses a json file, calculates the start_time of each function and prunes the tree so that only nodes which have (some) overlap with the time interval specified, will remain.

Usage: 
```
$  g++ -std=c++11 -o tree_parser main.cpp tree_parse.cpp
$  ./tree_parser
```

Use data2.json file name as an input for the stack tree.
Time thresholds can be modified inside main.cpp (threshold_left, threshold_right).
