### PR TITLE
Time selection based on samples

### DIFF
--- a/src/wasm/tree_parse.cpp
+++ b/src/wasm/tree_parse.cpp
@@ -1,46 +1,68 @@
 #include "tree_parse.hpp"
 
-uint64_t calculate_left_sum(TreeNode &node, uint64_t &running_sum) {
-  if (node.children.empty()) {
-    // left_sum is the starting_time for the current function
-    node.left_sum = running_sum;
-    // sum of leaf values (walltimes) to the left = start_time current
-    running_sum += node.value;
-  } else {
-    for (auto &child : node.children) {
-      calculate_left_sum(child, running_sum);
-    }
-    if (!node.children.empty()) {
-      // parent start_time = left most child start_time
-      node.left_sum = node.children.front().left_sum;
-    }
-  }
-  return node.left_sum;
-}
-
 TreeNode prune_tree(const TreeNode &node, uint64_t threshold_left,
-                    uint64_t threshold_right) {
+                    uint64_t threshold_right, const std::string counter_name) {
   TreeNode pruned_node = node;
 
   pruned_node.children.clear();
 
-  for (const auto &child : node.children) {
-    // this includes all the functions that have any overlap
-    // with the time between the two thresholds
-    if ((child.left_sum + child.value) > threshold_left &&
-        child.left_sum < threshold_right) {
-      pruned_node.children.push_back(prune_tree(child, threshold_left,
-                                                threshold_right));
+  if (node.children.empty()) {  // if leaf node remove samples outside time interval and subtract from total value
+    uint64_t extra_value = 0;
+
+    for (auto it = pruned_node.samples.begin(); it != pruned_node.samples.end();) {
+      if (counter_name == "walltime"){ //if walltime, make a more refined guess of the zoomed-in walltime of the current node
+          if (it->timestamp - it->value < threshold_left && it->timestamp >= threshold_left){
+            extra_value += threshold_left - (it->timestamp - it->value);
+            ++it;
+          }
+          else if (it->timestamp - it->value < threshold_right && it->timestamp >= threshold_right){
+            extra_value += it->timestamp - threshold_right;
+            ++it;
+          }
+          else if (it->timestamp < threshold_left || it->timestamp > threshold_right){
+            extra_value += it->value;
+            it = pruned_node.samples.erase(it);
+          }
+          else{
+            ++it;
+          }
+      }
+      else //for other types of counters, just substract the period
+      {
+
+        if (it->timestamp < threshold_left || it->timestamp > threshold_right)
+        {
+          extra_value += it->value;
+          it = pruned_node.samples.erase(it);
+        }
+        else
+        {
+          ++it;
+        }
+      }
+    }
+    pruned_node.value -= extra_value;
+    if (pruned_node.value == 0) {
+        return {}; //no value, means it would not be displayed 
+    }
+
+  } else { 
+    pruned_node.value = 0;
+
+    for (const auto &child : node.children) {
+        TreeNode pruned_child = prune_tree(child, threshold_left, threshold_right, counter_name);
+
+        // add the child if after extra counters (outside timeinterval) where substracted, final value > 0
+        if (pruned_child.value > 0) {
+          pruned_node.children.push_back(pruned_child);
+          pruned_node.value += pruned_child.value; //new value of parent is sum of children values
+        }
+    }
+
+    if (pruned_node.value == 0 && pruned_node.children.empty()) {
+        return {}; 
     }
   }
-
-  uint64_t extra_time_left =
-    threshold_left > node.left_sum ? threshold_left - node.left_sum : 0;
-  uint64_t extra_time_right =
-    (node.left_sum + node.value) > threshold_right ?
-    node.left_sum + node.value - threshold_right : 0;
-  // substract extra left + right time intervals from walltime if any
-  pruned_node.value = node.value - extra_time_left - extra_time_right;
 
   return pruned_node;
 }

--- a/src/wasm/tree_parse.hpp
+++ b/src/wasm/tree_parse.hpp
@@ -6,16 +6,22 @@
 #include <string>
 #include <cstdint>
 
+
+struct Sample {
+  uint64_t timestamp;
+  uint64_t value;
+};
+
 struct TreeNode {
   std::string name;
   uint64_t value;
   uint64_t left_sum;
   bool cold;
+  std::vector<Sample> samples;
   std::vector<TreeNode> children;
 };
 
-uint64_t calculate_left_sum(TreeNode &node, uint64_t &running_sum);
 TreeNode prune_tree(const TreeNode &node, uint64_t threshold_left,
-                    uint64_t threshold_right);
+                    uint64_t threshold_right, const std::string counter_name);
 
 #endif // TREE_PARSE_H


### PR DESCRIPTION
I changed a bit the logic for clipping the tree because the previous logic only worked for walltime. 
Now I am modifying the values by subtracting the periods of samples from outside the selected time interval.
 For walltime, I do the same thing but for samples have the period bigger than the difference between the sample timestamp and the time threshold, I substact only the part of the period that is not overlapping on the time interval.
